### PR TITLE
Fix V8 build error on Node12

### DIFF
--- a/src/main.cc
+++ b/src/main.cc
@@ -44,7 +44,7 @@ void SpawnAsAdmin(const Nan::FunctionCallbackInfo<Value>& info) {
   std::vector<std::string> args;
   args.reserve(js_args->Length());
   for (uint32_t i = 0; i < js_args->Length(); ++i) {
-    Local<Value> js_arg = js_args->Get(i);
+    Local<Value> js_arg = js_args->Get(Nan::GetCurrentContext(), i).ToLocalChecked();
     if (!js_arg->IsString()) {
       Nan::ThrowTypeError("Arguments must be an array of strings");
       return;
@@ -65,9 +65,9 @@ void SpawnAsAdmin(const Nan::FunctionCallbackInfo<Value>& info) {
   if (child_process.pid == -1) return;
 
   Local<Object> result = Nan::New<Object>();
-  result->Set(Nan::New("pid").ToLocalChecked(), Nan::New<Integer>(child_process.pid));
-  result->Set(Nan::New("stdin").ToLocalChecked(), Nan::New<Integer>(child_process.stdin_file_descriptor));
-  result->Set(Nan::New("stdout").ToLocalChecked(), Nan::New<Integer>(child_process.stdout_file_descriptor));
+  result->Set(Nan::GetCurrentContext(), Nan::New("pid").ToLocalChecked(), Nan::New<Integer>(child_process.pid));
+  result->Set(Nan::GetCurrentContext(), Nan::New("stdin").ToLocalChecked(), Nan::New<Integer>(child_process.stdin_file_descriptor));
+  result->Set(Nan::GetCurrentContext(), Nan::New("stdout").ToLocalChecked(), Nan::New<Integer>(child_process.stdout_file_descriptor));
   info.GetReturnValue().Set(result);
 
   Nan::AsyncQueueWorker(new Worker(new Nan::Callback(info[2].As<Function>()), child_process, test_mode));


### PR DESCRIPTION
### Identify the Bug

When I used this with  node 12.13.1, electron 8.3.4, and electron-rebuild 1.11.0, the following error was thrown.

```
Error:   CXX(target) Release/obj.target/spawn_as_admin/src/main.o
In file included from ../src/main.cc:1:

..................

../src/main.cc:47:36: error: no matching member function for call to 'Get'
    Local<Value> js_arg = js_args->Get(i);
                          ~~~~~~~~~^~~
/Users/itonozomi/.electron-gyp/8.3.4/include/node/v8.h:3658:43: note: candidate function not viable: requires 2 arguments, but 1 was provided
  V8_WARN_UNUSED_RESULT MaybeLocal<Value> Get(Local<Context> context,
                                          ^
/Users/itonozomi/.electron-gyp/8.3.4/include/node/v8.h:3661:43: note: candidate function not viable: requires 2 arguments, but 1 was provided
  V8_WARN_UNUSED_RESULT MaybeLocal<Value> Get(Local<Context> context,
                                          ^
../src/main.cc:68:11: error: no matching member function for call to 'Set'
  result->Set(Nan::New("pid").ToLocalChecked(), Nan::New<Integer>(child_process.pid));
  ~~~~~~~~^~~
/Users/itonozomi/.electron-gyp/8.3.4/include/node/v8.h:3611:37: note: candidate function not viable: requires 3 arguments, but 2 were provided
  V8_WARN_UNUSED_RESULT Maybe<bool> Set(Local<Context> context,
                                    ^
/Users/itonozomi/.electron-gyp/8.3.4/include/node/v8.h:3614:37: note: candidate function not viable: requires 3 arguments, but 2 were provided
  V8_WARN_UNUSED_RESULT Maybe<bool> Set(Local<Context> context, uint32_t index,
                                    ^
../src/main.cc:69:11: error: no matching member function for call to 'Set'
  result->Set(Nan::New("stdin").ToLocalChecked(), Nan::New<Integer>(child_process.stdin_file_descriptor));
  ~~~~~~~~^~~
/Users/itonozomi/.electron-gyp/8.3.4/include/node/v8.h:3611:37: note: candidate function not viable: requires 3 arguments, but 2 were provided
  V8_WARN_UNUSED_RESULT Maybe<bool> Set(Local<Context> context,
                                    ^
/Users/itonozomi/.electron-gyp/8.3.4/include/node/v8.h:3614:37: note: candidate function not viable: requires 3 arguments, but 2 were provided
  V8_WARN_UNUSED_RESULT Maybe<bool> Set(Local<Context> context, uint32_t index,
                                    ^
../src/main.cc:70:11: error: no matching member function for call to 'Set'
  result->Set(Nan::New("stdout").ToLocalChecked(), Nan::New<Integer>(child_process.stdout_file_descriptor));
  ~~~~~~~~^~~
/Users/itonozomi/.electron-gyp/8.3.4/include/node/v8.h:3611:37: note: candidate function not viable: requires 3 arguments, but 2 were provided
  V8_WARN_UNUSED_RESULT Maybe<bool> Set(Local<Context> context,
                                    ^
/Users/itonozomi/.electron-gyp/8.3.4/include/node/v8.h:3614:37: note: candidate function not viable: requires 3 arguments, but 2 were provided
  V8_WARN_UNUSED_RESULT Maybe<bool> Set(Local<Context> context, uint32_t index,
                                    ^
2 warnings and 4 errors generated.
```

It seems   due to method signature mismatch of Get/Set method in [v8 for node12](https://v8docs.nodesource.com/node-12.0/d3/d32/classv8_1_1_array.html).

### Description of the Change

Change the method call of Set/Get so that it works with node12 v8.
I assume this library supports node12 since I saw https://github.com/atom/spawn-as-admin/pull/4.

### Possible Drawbacks

After this change, spawn-as-admin might not work on very old V8.
